### PR TITLE
Updated for glibc version >= 2.26 compatibility.

### DIFF
--- a/qemu_mode/qemu/hw/9pfs/virtio-9p.c
+++ b/qemu_mode/qemu/hw/9pfs/virtio-9p.c
@@ -20,6 +20,9 @@
 #include "virtio-9p-coth.h"
 #include "trace.h"
 #include "migration/migration.h"
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 26
+#include <sys/sysmacros.h>
+#endif
 
 int open_fd_hw;
 int total_open_fd;

--- a/qemu_mode/qemu/linux-user/strace.c
+++ b/qemu_mode/qemu/linux-user/strace.c
@@ -5,6 +5,9 @@
 #include <sys/shm.h>
 #include <sys/select.h>
 #include <sys/types.h>
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 26
+#include <sys/sysmacros.h>
+#endif
 #include <sys/mount.h>
 #include <sys/mman.h>
 #include <unistd.h>

--- a/qemu_mode/qemu/qga/commands-posix.c
+++ b/qemu_mode/qemu/qga/commands-posix.c
@@ -13,6 +13,9 @@
 
 #include <glib.h>
 #include <sys/types.h>
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 26
+#include <sys/sysmacros.h>
+#endif
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/qemu_mode/qemu/user-exec.c
+++ b/qemu_mode/qemu/user-exec.c
@@ -57,7 +57,11 @@ static void exception_action(CPUState *cpu)
 void cpu_resume_from_signal(CPUState *cpu, void *puc)
 {
 #ifdef __linux__
+#if __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 26
+    struct ucontext_t *uc = puc;
+#else
     struct ucontext *uc = puc;
+#endif
 #elif defined(__OpenBSD__)
     struct sigcontext *uc = puc;
 #endif
@@ -209,6 +213,11 @@ int cpu_signal_handler(int host_signum, void *pinfo,
 #define TRAP_sig(context)     ((context)->uc_mcontext.mc_trapno)
 #define ERROR_sig(context)    ((context)->uc_mcontext.mc_err)
 #define MASK_sig(context)     ((context)->uc_sigmask)
+#elif __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 26
+#define PC_sig(context)       (((struct ucontext_t *)context)->uc_mcontext.gregs[REG_RIP])
+#define TRAP_sig(context)     (((struct ucontext_t *)context)->uc_mcontext.gregs[REG_TRAPNO])
+#define ERROR_sig(context)    (((struct ucontext_t *)context)->uc_mcontext.gregs[REG_ERR])
+#define MASK_sig(context)     (((struct ucontext_t *)context)->uc_sigmask)
 #else
 #define PC_sig(context)       ((context)->uc_mcontext.gregs[REG_RIP])
 #define TRAP_sig(context)     ((context)->uc_mcontext.gregs[REG_TRAPNO])


### PR DESCRIPTION
Recent changes in glibc 2.26 have caused the build to break. The main problem is that `sys/types.h` no longer exports `sys/sysmacros.h`. The secondary problem is that `struct ucontext` has been renamed `struct ucontext_t`. These changes in glibc were confirmed by the changelogs (visible online [here](https://abi-laboratory.pro/?view=changelog&l=glibc&v=2.26)).

Edit: this appears to resolve issue #4 as well.